### PR TITLE
Adds 2024 Robot Visualization

### DIFF
--- a/webapp/src/components/displays/display-mapper.tsx
+++ b/webapp/src/components/displays/display-mapper.tsx
@@ -61,7 +61,7 @@ export function getDefaultType(entry: NTEntry) {
             if(numberArrayValue.length === 3) {
                 return DisplayType.Field;
             }
-            if(entry.key.toLowerCase().includes('Robot2024')) {
+            if(entry.key.toLowerCase().includes('robot2024/state')) {
                 return DisplayType.Robot2024;
             }
             if(entry.key.toLowerCase().includes('arm')) {

--- a/webapp/src/components/displays/robot-display-2024.tsx
+++ b/webapp/src/components/displays/robot-display-2024.tsx
@@ -12,6 +12,21 @@ const chaosOrange = '#ff6700';
 const chaosGreenTransparent = chaosGreen + 'ee';
 const chaosOrangeTransparent = chaosOrange + '77';
 
+const getDirectionColor = (power: number, frameCount: number) => {
+  if (frameCount % 50 > 40) {
+    return '#80808022'
+  }
+  if (power === 0) {
+    return '#80808055';
+  }
+  const opacity = (Math.abs(power / 1) / 2) + 0.25;
+  if (power > 0) {
+    return `rgba(0, 255, 0, ${opacity})`;
+  } else {
+    return `rgba(255, 100, 0, ${opacity})`;
+  }
+}
+
 type ArmDisplayProps = {
   entry: NTEntry | undefined,
 };
@@ -22,7 +37,7 @@ type ArmDisplayProps = {
 export function RobotDisplay2024({ entry }: ArmDisplayProps) {
   const [ch] = useState(new CanvasHelper(1.5));
 
-  const draw = (context: CanvasRenderingContext2D, [intakePower, liftHeightMeters, launcherAngleDegrees, launcherPower]: (number | undefined)[], frameCount: number) => {
+  const draw = (context: CanvasRenderingContext2D, [intakePower, liftHeightMeters, launcherAngleDegrees, feederPower, launcherPower]: (number | undefined)[], frameCount: number) => {
     // wheels
     const wheelDiameterMeters = 0.102;
     const wheelLeft = ch.createShape(wheelDiameterMeters, wheelDiameterMeters, -0.27, 0.0, 'black');
@@ -50,13 +65,21 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     const platformEnd = ch.drawLine(context, liftEnd, liftPlatformAngleDegrees, platformLength, 'silver', ch.metersToPixels(platformWidth));
 
     // launcher
-    launcherAngleDegrees = (launcherAngleDegrees ?? 0) + 180;
+    const launcherAngleDegreesConverted = (launcherAngleDegrees ?? 0) + 180;
     const launcherLength = 0.333747;
     const launcherWidth = 0.1;
-    ch.drawLine(context, platformEnd, launcherAngleDegrees, launcherLength, chaosOrangeTransparent, ch.metersToPixels(launcherWidth));
+    const launcherColor = getDirectionColor(launcherPower ?? 0, frameCount);
+    ch.drawLine(context, platformEnd, launcherAngleDegreesConverted, launcherLength, launcherColor, ch.metersToPixels(launcherWidth));
+
+    // feeder
+    const feederAngle = (launcherAngleDegrees ?? 0) - 20;
+    const feederLength = 0.05;
+    const feederWidth = 0.1;
+    const feederColor = getDirectionColor(feederPower ?? 0, frameCount);
+    ch.drawLine(context, platformEnd, feederAngle, feederLength, feederColor, ch.metersToPixels(feederWidth));
 
     // static lift beam
-    const beamLength = 0.547852; // todo: confirm
+    const beamLength = 0.547852;
     const beamWidth = 0.050800;
     ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), liftAngleDegrees, beamLength, chaosGreen, ch.metersToPixels(beamWidth));
 
@@ -65,6 +88,13 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     const braceWidth = 0.025400;
     const braceAngleDegrees = 49.157005;
     ch.drawLine(context, ch.getCoordinateFromMeters(-0.308817, 0.180586), braceAngleDegrees, braceLength, chaosGreen, ch.metersToPixels(braceWidth));
+
+    // intake
+    const intakeLength = 0.3;
+    const intakeWidth = 0.072599;
+    const intakeAngleDegrees = 110;
+    const intakeColor = getDirectionColor(intakePower ?? 0, frameCount);
+    ch.drawLine(context, ch.getCoordinateFromMeters(0.432365, 0.031797), intakeAngleDegrees, intakeLength, intakeColor, ch.metersToPixels(intakeWidth));
 
     // bumpers
     const bumbersWidth = 0.990092;

--- a/webapp/src/components/displays/robot-display-2024.tsx
+++ b/webapp/src/components/displays/robot-display-2024.tsx
@@ -3,9 +3,12 @@ import { NTEntry } from './../../data/nt-manager';
 import {
   ChaosCanvas,
   CanvasHelper,
+  Coordinate,
 } from './util/chaos-canvas';
 
 const chaosGreen = '#134122';
+const chaosAltGreen = '#9fc7ad';
+const chaosOrange = '#ff6700';
 const chaosGreenTransparent = chaosGreen + 'ee';
 
 type ArmDisplayProps = {
@@ -18,7 +21,7 @@ type ArmDisplayProps = {
 export function RobotDisplay2024({ entry }: ArmDisplayProps) {
   const [ch] = useState(new CanvasHelper(1.5));
 
-  const draw = (context: CanvasRenderingContext2D, [_]: (number | undefined)[], frameCount: number) => {
+  const draw = (context: CanvasRenderingContext2D, [intakeSpeed, liftHeightMeters]: (number | undefined)[], frameCount: number) => {
     // wheels
     const wheelDiameterMeters = 0.102;
     const wheelLeft = ch.createShape(wheelDiameterMeters, wheelDiameterMeters, -0.27, 0.0, 'black');
@@ -33,11 +36,23 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     const basePlate = ch.createShape(basePlateWidth, basePlateheight, 0, basePlateHeightOffGround, 'silver');
     ch.drawRoundRectangle(context, basePlate, basePlate.heightPixels / 3);
 
+    // Lift Height
+    liftHeightMeters = liftHeightMeters ?? 0.547852;
+    // liftHeightMeters = 1; // TODO: change
+    const liftWidth = 0.050800;
+    const liftAngleDegrees = 80;
+    const liftEnd = ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), liftAngleDegrees, liftHeightMeters, chaosAltGreen, ch.metersToPixels(liftWidth));
+
+    // lift platform
+    const liftPlatformAngleDegrees = -11.826423;
+    const platformLength = 0.340474;
+    const platformWidth = 0.02;
+    const platformEnd = ch.drawLine(context, liftEnd, liftPlatformAngleDegrees, platformLength, 'silver', ch.metersToPixels(platformWidth));
+
     // static lift beam
     const beamLength = 0.547852; // todo: confirm
     const beamWidth = 0.050800;
-    const beamAngleDegrees = 80;
-    ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), beamAngleDegrees, beamLength, chaosGreen, ch.metersToPixels(beamWidth));
+    ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), liftAngleDegrees, beamLength, chaosGreen, ch.metersToPixels(beamWidth));
 
     // static lift brace
     const braceLength = 0.446015;

--- a/webapp/src/components/displays/robot-display-2024.tsx
+++ b/webapp/src/components/displays/robot-display-2024.tsx
@@ -10,6 +10,7 @@ const chaosGreen = '#134122';
 const chaosAltGreen = '#9fc7ad';
 const chaosOrange = '#ff6700';
 const chaosGreenTransparent = chaosGreen + 'ee';
+const chaosOrangeTransparent = chaosOrange + '77';
 
 type ArmDisplayProps = {
   entry: NTEntry | undefined,
@@ -21,7 +22,7 @@ type ArmDisplayProps = {
 export function RobotDisplay2024({ entry }: ArmDisplayProps) {
   const [ch] = useState(new CanvasHelper(1.5));
 
-  const draw = (context: CanvasRenderingContext2D, [intakeSpeed, liftHeightMeters]: (number | undefined)[], frameCount: number) => {
+  const draw = (context: CanvasRenderingContext2D, [intakePower, liftHeightMeters, launcherAngleDegrees, launcherPower]: (number | undefined)[], frameCount: number) => {
     // wheels
     const wheelDiameterMeters = 0.102;
     const wheelLeft = ch.createShape(wheelDiameterMeters, wheelDiameterMeters, -0.27, 0.0, 'black');
@@ -37,8 +38,7 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     ch.drawRoundRectangle(context, basePlate, basePlate.heightPixels / 3);
 
     // Lift Height
-    liftHeightMeters = liftHeightMeters ?? 0.547852;
-    // liftHeightMeters = 1; // TODO: change
+    liftHeightMeters = liftHeightMeters ?? 0.35;
     const liftWidth = 0.050800;
     const liftAngleDegrees = 80;
     const liftEnd = ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), liftAngleDegrees, liftHeightMeters, chaosAltGreen, ch.metersToPixels(liftWidth));
@@ -48,6 +48,12 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     const platformLength = 0.340474;
     const platformWidth = 0.02;
     const platformEnd = ch.drawLine(context, liftEnd, liftPlatformAngleDegrees, platformLength, 'silver', ch.metersToPixels(platformWidth));
+
+    // launcher
+    launcherAngleDegrees = (launcherAngleDegrees ?? 0) + 180;
+    const launcherLength = 0.333747;
+    const launcherWidth = 0.1;
+    ch.drawLine(context, platformEnd, launcherAngleDegrees, launcherLength, chaosOrangeTransparent, ch.metersToPixels(launcherWidth));
 
     // static lift beam
     const beamLength = 0.547852; // todo: confirm

--- a/webapp/src/components/displays/robot-display-2024.tsx
+++ b/webapp/src/components/displays/robot-display-2024.tsx
@@ -56,7 +56,7 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     liftHeightMeters = liftHeightMeters ?? 0.35;
     const liftWidth = 0.050800;
     const liftAngleDegrees = 80;
-    const liftEnd = ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), liftAngleDegrees, liftHeightMeters, chaosAltGreen, ch.metersToPixels(liftWidth));
+    const liftEnd = ch.drawLine(context, ch.getCoordinateFromMeters(-0.091682, 0.071550), liftAngleDegrees, liftHeightMeters, chaosAltGreen, ch.metersToPixels(liftWidth));
 
     // lift platform
     const liftPlatformAngleDegrees = -11.826423;
@@ -81,7 +81,7 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     // static lift beam
     const beamLength = 0.547852;
     const beamWidth = 0.050800;
-    ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), liftAngleDegrees, beamLength, chaosGreen, ch.metersToPixels(beamWidth));
+    ch.drawLine(context, ch.getCoordinateFromMeters(-0.091682, 0.071550), liftAngleDegrees, beamLength, chaosGreen, ch.metersToPixels(beamWidth));
 
     // static lift brace
     const braceLength = 0.446015;

--- a/webapp/src/components/displays/robot-display-2024.tsx
+++ b/webapp/src/components/displays/robot-display-2024.tsx
@@ -5,6 +5,9 @@ import {
   CanvasHelper,
 } from './util/chaos-canvas';
 
+const chaosGreen = '#134122';
+const chaosGreenTransparent = chaosGreen + 'ee';
+
 type ArmDisplayProps = {
   entry: NTEntry | undefined,
 };
@@ -13,7 +16,7 @@ type ArmDisplayProps = {
  * The physical arm was dismantled, so this remains mostly for reference.
  */
 export function RobotDisplay2024({ entry }: ArmDisplayProps) {
-  const [ch] = useState(new CanvasHelper(3));
+  const [ch] = useState(new CanvasHelper(1.5));
 
   const draw = (context: CanvasRenderingContext2D, [_]: (number | undefined)[], frameCount: number) => {
     // wheels
@@ -30,12 +33,24 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     const basePlate = ch.createShape(basePlateWidth, basePlateheight, 0, basePlateHeightOffGround, 'silver');
     ch.drawRoundRectangle(context, basePlate, basePlate.heightPixels / 3);
 
+    // static lift beam
+    const beamLength = 0.547852; // todo: confirm
+    const beamWidth = 0.050800;
+    const beamAngleDegrees = 80;
+    ch.drawLine(context, ch.getCoordinateFromMeters(-0.096682, 0.071550), beamAngleDegrees, beamLength, chaosGreen, ch.metersToPixels(beamWidth));
+
+    // static lift brace
+    const braceLength = 0.446015;
+    const braceWidth = 0.025400;
+    const braceAngleDegrees = 49.157005;
+    ch.drawLine(context, ch.getCoordinateFromMeters(-0.308817, 0.180586), braceAngleDegrees, braceLength, chaosGreen, ch.metersToPixels(braceWidth));
+
     // bumpers
     const bumbersWidth = 0.990092;
     const bumbersHeight = 0.129032;
     const bumperHeightOffGround = 0.057150;
     const bumpersOffset = 0.539496 - (0.990092 / 2);
-    const bumpers = ch.createShape(bumbersWidth, bumbersHeight, bumpersOffset, bumperHeightOffGround, 'forestgreen');
+    const bumpers = ch.createShape(bumbersWidth, bumbersHeight, bumpersOffset, bumperHeightOffGround, chaosGreenTransparent);
     ch.drawRoundRectangle(context, bumpers, bumpers.heightPixels / 3);
     ch.addTextToShape(context, bumpers, '131', 'white', 50);
   };

--- a/webapp/src/components/displays/robot-display-2024.tsx
+++ b/webapp/src/components/displays/robot-display-2024.tsx
@@ -65,14 +65,14 @@ export function RobotDisplay2024({ entry }: ArmDisplayProps) {
     const platformEnd = ch.drawLine(context, liftEnd, liftPlatformAngleDegrees, platformLength, 'silver', ch.metersToPixels(platformWidth));
 
     // launcher
-    const launcherAngleDegreesConverted = (launcherAngleDegrees ?? 0) + 180;
+    const launcherAngleDegreesConverted = 180 - (launcherAngleDegrees ?? 0);
     const launcherLength = 0.333747;
     const launcherWidth = 0.1;
     const launcherColor = getDirectionColor(launcherPower ?? 0, frameCount);
     ch.drawLine(context, platformEnd, launcherAngleDegreesConverted, launcherLength, launcherColor, ch.metersToPixels(launcherWidth));
 
     // feeder
-    const feederAngle = (launcherAngleDegrees ?? 0) - 20;
+    const feederAngle = launcherAngleDegreesConverted - 200;
     const feederLength = 0.05;
     const feederWidth = 0.1;
     const feederColor = getDirectionColor(feederPower ?? 0, frameCount);

--- a/webapp/src/components/displays/util/chaos-canvas.tsx
+++ b/webapp/src/components/displays/util/chaos-canvas.tsx
@@ -52,11 +52,11 @@ export class CanvasHelper {
         context.fillText(text, shape.coordinate.xPixels + (shape.widthPixels / 2), shape.coordinate.yPixels + (shape.heightPixels / 2));
     }
     
-    drawLine = (context: CanvasRenderingContext2D, start: Coordinate, angleDegrees: number, lengthMeters: number, color: string, width: number) => {
+    drawLine = (context: CanvasRenderingContext2D, start: Coordinate, angleDegrees: number, lengthMeters: number, color: string, widthPixels: number) => {
         const startXPixel = start.xPixels;
         const startYPixel = start.yPixels;
         context.strokeStyle = color;
-        context.lineWidth = width;
+        context.lineWidth = widthPixels;
         context.beginPath();
         context.moveTo(startXPixel, startYPixel);
         let angleRadians = angleDegrees * Math.PI / 180;


### PR DESCRIPTION
This adds a robot visualizer for the 2024 bot. Dimensions are taken/inspired from OnShape CAD, but not entirely accurate. 


https://github.com/Manchester-Central/chaosboard/assets/6991773/77623bd8-2a44-4033-9608-941024dd312b

